### PR TITLE
pause() doesn't work from within a callback

### DIFF
--- a/angular-queue.js
+++ b/angular-queue.js
@@ -127,6 +127,9 @@ angular.module('ngQueue', []).factory('$queue',
                         var item;
 
                         stop();
+                        
+                        if(_this.paused)
+                            return;
 
                         if (!_this.size()) {
                             cleared = true;


### PR DESCRIPTION
I added this to the pause function

``` javascript
console.log("PAUSE");
```

And I changed myCallback() from the example to

``` javascript
var myCallback = function(item) {
    console.log(item);
    myQueue.pause();
};
```

My output was

```
item 1
PAUSE
item 2
PAUSE
item 3
PAUSE
complete!
```

so clearly the pause function is being called, but not actually pausing anything. I did some investigation. The function stop() is successful in setting timeoutProm to null, but loopy() calls myCallback before setting the new value of timeoutProm. So while myCallback manages to set timeoutProm to null, timeoutProm still gets set to a valid object before that iteration of loopy() is done.

The fix that I included in this pull request was to add a return statement which checks if loopy() is running when it shouldn't. However, I also tried swapping the order of calling the callback and assigning the new timeoutProm, and that looks like this:

``` javascript
(function loopy() {                     
    var item;

    stop();

    if (!_this.size()) {
        cleared = true;
        if (angular.isFunction(_this.complete)) {
            _this.complete.call(_this);
        }
         return;
    }

    item = _this.queue.shift();

    timeoutProm = $timeout(loopy,
        _this.delay);

    _this.callback.call(_this, item);

    return;
})();
```

In my (admittedly brief) testing, there is no real difference between the two fixes. The first sets the pause variable in the callback and when loopy() runs again it calls stop() to actually stop the operation. My return statement then aborts the function before the callback can be called on the current item and a new item can be shifted off the queue. This means when start() is called, the queue is able to resume with the item it was previously using. The second fix where you switch the order is more efficient because loopy() isn't run an unnecessary time, but it makes the value of timeoutProm that is relevant to the current callback unavailable. Instead the callback can only manipulate the timeoutProm that belongs to the future. I know timeoutProm is a private variable, but who knows what features will be added in the future that this could interfere with. If you really don't plan on extending this project anymore, then the second fix is probably the better option.
